### PR TITLE
Fix issue with new data structure in ranger >=0.11.5

### DIFF
--- a/src/tidyRF.cpp
+++ b/src/tidyRF.cpp
@@ -188,7 +188,10 @@ Rcpp::List tidyRFCpp_ranger(
     const Rcpp::CharacterVector original_feature_names = trainX.names();
     Rcpp::IntegerVector reorder
         = Rcpp::match(rf_feature_names, original_feature_names) - 1;
-    reorder.push_front(NA_INTEGER);
+    if (forest.containsElementNamed("dependent.varID")) {
+        // For ranger version <0.11.5
+        reorder.push_front(NA_INTEGER);
+    }
 
     Rcpp::List split_variables_ensemble(num_trees);
     for (int tree = 0; tree < num_trees; tree++) {


### PR DESCRIPTION
Fixes issue here https://cran.r-project.org/web/checks/check_results_tree.interpreter.html. 

We changed the internal data structure in ranger (now separate X and Y data). 